### PR TITLE
fix(types): make selectors array read only

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,9 @@ export type Selector =
   | {| $log: string |};
 
 export type Watcher = {|
-  sources: Array<string | null>,
+  sources: $ReadOnlyArray<string | null>,
   tag: string,
-  selectors: Array<Selector>
+  selectors: $ReadOnlyArray<Selector>
 |};
 
 export type Finder = {|


### PR DESCRIPTION
I noticed that Flow was complaining about variance when passing an array from `String#split` to `selectors` - it doesn't seem to understand that `split` doesn't retain a reference to the returned array.